### PR TITLE
Add PNG and JPG download options

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,25 +604,33 @@
 
         function downloadCanvasImage(type) {
             const mime = type === 'jpg' ? 'image/jpeg' : 'image/png';
+            const EXPORT_SIZE = 2000;
+
             const exportCanvas = document.createElement('canvas');
-            const EXPORT_SIZE = 2000; // target resolution
             exportCanvas.width = EXPORT_SIZE;
             exportCanvas.height = EXPORT_SIZE;
             const exportCtx = exportCanvas.getContext('2d');
 
-            if (type === 'jpg') {
-                exportCtx.fillStyle = '#ffffff';
-                exportCtx.fillRect(0, 0, EXPORT_SIZE, EXPORT_SIZE);
-            }
+            const svgString = generateSVGString();
+            const img = new Image();
+            const url = URL.createObjectURL(new Blob([svgString], { type: 'image/svg+xml' }));
 
-            exportCtx.drawImage(canvas, 0, 0, EXPORT_SIZE, EXPORT_SIZE);
+            img.onload = () => {
+                if (type === 'jpg') {
+                    exportCtx.fillStyle = '#ffffff';
+                    exportCtx.fillRect(0, 0, EXPORT_SIZE, EXPORT_SIZE);
+                }
+                exportCtx.drawImage(img, 0, 0, EXPORT_SIZE, EXPORT_SIZE);
+                URL.revokeObjectURL(url);
+                const a = document.createElement('a');
+                a.href = exportCanvas.toDataURL(mime);
+                a.download = `sdg_height_chart.${type}`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+            };
 
-            const a = document.createElement('a');
-            a.href = exportCanvas.toDataURL(mime);
-            a.download = `sdg_height_chart.${type}`;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
+            img.src = url;
         }
 
         // Initialize

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
             background-color: #fff;
             border-radius: 8px;
         }
-        #downloadSVGButton {
+        .download-button {
             display: block;
             margin: 15px auto 5px;
             padding: 8px 15px;
@@ -122,7 +122,7 @@
             cursor: pointer;
             font-size: 0.9em;
         }
-        #downloadSVGButton:hover {
+        .download-button:hover {
             background-color: #0056b3;
         }
         h2, h3 {
@@ -174,7 +174,9 @@
     <div id="graph-container">
         <h2>SDG Radial Chart Generator</h2>
         <canvas id="sdgCanvas" width="500" height="500"></canvas>
-        <button id="downloadSVGButton">Download as SVG</button>
+        <button id="downloadSVGButton" class="download-button">Download as SVG</button>
+        <button id="downloadPNGButton" class="download-button">Download as PNG</button>
+        <button id="downloadJPGButton" class="download-button">Download as JPG</button>
     </div>
 
     <script>
@@ -197,6 +199,8 @@
         const ctx = canvas.getContext('2d');
         const sdgControlsListContainer = document.getElementById('sdg-controls-list');
         const downloadButton = document.getElementById('downloadSVGButton');
+        const downloadPNGButton = document.getElementById('downloadPNGButton');
+        const downloadJPGButton = document.getElementById('downloadJPGButton');
         const customMinInput = document.getElementById('customMinRange');
         const customMaxInput = document.getElementById('customMaxRange');
         const applyRangeButton = document.getElementById('applyRangeButton');
@@ -598,10 +602,22 @@
             URL.revokeObjectURL(url);
         }
 
+        function downloadCanvasImage(type) {
+            const mime = type === 'jpg' ? 'image/jpeg' : 'image/png';
+            const a = document.createElement('a');
+            a.href = canvas.toDataURL(mime);
+            a.download = `sdg_height_chart.${type}`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+        }
+
         // Initialize
         applyRangeButton.addEventListener('click', applyCustomRange);
         csvFileUploadInput.addEventListener('change', handleCSVUpload);
         downloadButton.addEventListener('click', downloadSVG);
+        downloadPNGButton.addEventListener('click', () => downloadCanvasImage('png'));
+        downloadJPGButton.addEventListener('click', () => downloadCanvasImage('jpg'));
         valueStrokeCheckbox.addEventListener('change', drawGraph);
 
         createSDGControls(); // Initial creation of SDG controls

--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@
             });
         }
 
-        function generateSVGString() {
+        function generateSVGString(whiteBackground = true) {
             let svgContent = '';
             const anglePerSegment = (2 * Math.PI) / NUM_SDGS;
 
@@ -581,8 +581,9 @@
                     }
                 }
             });
+            const bgStyle = whiteBackground ? ' style="background-color: #fff;"' : '';
             return `
-<svg width="${CANVAS_WIDTH}" height="${CANVAS_HEIGHT}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color: #fff;">
+<svg width="${CANVAS_WIDTH}" height="${CANVAS_HEIGHT}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"${bgStyle}>
   <g transform="translate(${centerX}, ${centerY})">
     ${svgContent}
   </g>
@@ -590,7 +591,7 @@
         }
 
         function downloadSVG() {
-            const svgString = generateSVGString();
+            const svgString = generateSVGString(true);
             const blob = new Blob([svgString], { type: 'image/svg+xml' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
@@ -611,7 +612,7 @@
             exportCanvas.height = EXPORT_SIZE;
             const exportCtx = exportCanvas.getContext('2d');
 
-            const svgString = generateSVGString();
+            const svgString = generateSVGString(type === 'jpg');
             const img = new Image();
             const url = URL.createObjectURL(new Blob([svgString], { type: 'image/svg+xml' }));
 

--- a/index.html
+++ b/index.html
@@ -604,8 +604,21 @@
 
         function downloadCanvasImage(type) {
             const mime = type === 'jpg' ? 'image/jpeg' : 'image/png';
+            const exportCanvas = document.createElement('canvas');
+            const EXPORT_SIZE = 2000; // target resolution
+            exportCanvas.width = EXPORT_SIZE;
+            exportCanvas.height = EXPORT_SIZE;
+            const exportCtx = exportCanvas.getContext('2d');
+
+            if (type === 'jpg') {
+                exportCtx.fillStyle = '#ffffff';
+                exportCtx.fillRect(0, 0, EXPORT_SIZE, EXPORT_SIZE);
+            }
+
+            exportCtx.drawImage(canvas, 0, 0, EXPORT_SIZE, EXPORT_SIZE);
+
             const a = document.createElement('a');
-            a.href = canvas.toDataURL(mime);
+            a.href = exportCanvas.toDataURL(mime);
             a.download = `sdg_height_chart.${type}`;
             document.body.appendChild(a);
             a.click();

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This web-based tool allows you to create and customize an interactive circular g
 *   **Dynamic Labels:**
     *   "SDG #" labels are positioned along a guide circle, following its curvature for a clean look.
     *   The current value for each segment is displayed within the segment itself (if space permits).
-*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations. PNG and JPG downloads are generated at 2000×2000 resolution (JPG with a white background).
+*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations. PNG and JPG downloads are generated from the SVG at 2000×2000 resolution (JPG with a white background) for crisp quality.
 *   **Responsive Design:** Controls and graph layout adjust for different screen sizes.
 
 ## How to Use
@@ -49,7 +49,7 @@ This web-based tool allows you to create and customize an interactive circular g
 4.  **View the Graph:** The circular graph on the right will update in real-time as you change values.
 5.  **Download the Chart:**
     *   Use the buttons below the graph to save it as **SVG**, **PNG**, or **JPG**.
-    *   PNG and JPG exports are saved at 2000×2000 pixels. The JPG has a white background.
+    *   PNG and JPG exports are generated from the SVG at 2000×2000 pixels, with a white background for JPG.
     *   The downloaded file will be named `sdg_height_chart` with the corresponding extension.
 
 ## File Structure

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This web-based tool allows you to create and customize an interactive circular g
 *   **Dynamic Labels:**
     *   "SDG #" labels are positioned along a guide circle, following its curvature for a clean look.
     *   The current value for each segment is displayed within the segment itself (if space permits).
-*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations.
+*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations. PNG and JPG downloads are generated at 2000×2000 resolution (JPG with a white background).
 *   **Responsive Design:** Controls and graph layout adjust for different screen sizes.
 
 ## How to Use
@@ -49,6 +49,7 @@ This web-based tool allows you to create and customize an interactive circular g
 4.  **View the Graph:** The circular graph on the right will update in real-time as you change values.
 5.  **Download the Chart:**
     *   Use the buttons below the graph to save it as **SVG**, **PNG**, or **JPG**.
+    *   PNG and JPG exports are saved at 2000×2000 pixels. The JPG has a white background.
     *   The downloaded file will be named `sdg_height_chart` with the corresponding extension.
 
 ## File Structure

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This web-based tool allows you to create and customize an interactive circular g
 *   **Dynamic Labels:**
     *   "SDG #" labels are positioned along a guide circle, following its curvature for a clean look.
     *   The current value for each segment is displayed within the segment itself (if space permits).
-*   **SVG Export:** Download the generated chart as a Scalable Vector Graphic (SVG) file for high-quality use in reports, presentations, or further editing.
+*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations.
 *   **Responsive Design:** Controls and graph layout adjust for different screen sizes.
 
 ## How to Use
@@ -47,9 +47,9 @@ This web-based tool allows you to create and customize an interactive circular g
         *   In the "Upload Data (CSV)" section, click "Choose File" and select your CSV.
         *   The graph and controls will update with the loaded data. A status message will indicate success or any parsing issues.
 4.  **View the Graph:** The circular graph on the right will update in real-time as you change values.
-5.  **Download as SVG:**
-    *   Click the "Download as SVG" button below the graph.
-    *   An SVG file named `sdg_height_chart.svg` will be downloaded to your computer.
+5.  **Download the Chart:**
+    *   Use the buttons below the graph to save it as **SVG**, **PNG**, or **JPG**.
+    *   The downloaded file will be named `sdg_height_chart` with the corresponding extension.
 
 ## File Structure
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This web-based tool allows you to create and customize an interactive circular g
 *   **Dynamic Labels:**
     *   "SDG #" labels are positioned along a guide circle, following its curvature for a clean look.
     *   The current value for each segment is displayed within the segment itself (if space permits).
-*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations. PNG and JPG downloads are generated from the SVG at 2000×2000 resolution (JPG with a white background) for crisp quality.
+*   **Export Options:** Download the chart as a Scalable Vector Graphic (SVG) or as a PNG/JPG image for easy use in reports or presentations. PNG and JPG downloads are generated from the SVG at 2000×2000 resolution (PNG keeps transparency while JPG has a white background) for crisp quality.
 *   **Responsive Design:** Controls and graph layout adjust for different screen sizes.
 
 ## How to Use
@@ -49,7 +49,7 @@ This web-based tool allows you to create and customize an interactive circular g
 4.  **View the Graph:** The circular graph on the right will update in real-time as you change values.
 5.  **Download the Chart:**
     *   Use the buttons below the graph to save it as **SVG**, **PNG**, or **JPG**.
-    *   PNG and JPG exports are generated from the SVG at 2000×2000 pixels, with a white background for JPG.
+    *   PNG and JPG exports are generated from the SVG at 2000×2000 pixels. PNG files retain transparency, while JPG files have a white background.
     *   The downloaded file will be named `sdg_height_chart` with the corresponding extension.
 
 ## File Structure


### PR DESCRIPTION
## Summary
- add PNG and JPG download buttons
- share a helper function to capture the canvas
- update README with new export instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845d1f14de0832f99e1b952fd8487f4